### PR TITLE
Rfid reading library v1 complete

### DIFF
--- a/Hardware and firmware/Firmware/Classes/Class_tests/RfidReader-class-test/RfidReader-class-test.ino
+++ b/Hardware and firmware/Firmware/Classes/Class_tests/RfidReader-class-test/RfidReader-class-test.ino
@@ -1,0 +1,42 @@
+#include <ElectroscreenSerial.h>
+#include <Potentiostat.h>
+#include <RfidReader.h>
+#include <SyringeControl.h>
+#include <SyringeDriver.h>
+
+void setup() {
+  Serial.begin(9600);
+
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+  Serial.println("Inside loop");
+  RfidReader rfid;
+  Serial.println("rfid initilised");
+  rfid.readRfid();
+  Serial.println("read method complete");
+
+  Serial.println("Testing access of variables in the array");
+  //Testing access of variables
+  for (int i=0; i<10; i++)
+  {
+    Serial.print(rfid.descriptor[i]); Serial.print(": "); Serial.println(*rfid.parameterOut[i]);
+  }
+
+  //Testing access of other variables not in the array but referenced by it
+  Serial.println("Testing direct access to variables (not through array)");
+  Serial.print("batch: "); Serial.println(rfid.batch);
+  Serial.print("analysis: "); Serial.println(rfid.analysis);
+  Serial.print("cutoff: "); Serial.println(rfid.cutoff);
+  Serial.print("rfidHigh: "); Serial.println(rfid.rfidHigh);
+  Serial.print("rfidLow: "); Serial.println(rfid.rfidLow);
+  Serial.print("rfidScan: "); Serial.println(rfid.rfidScan);
+  Serial.print("rfidRepeat: "); Serial.println(rfid.rfidRepeat);
+  Serial.print("expiry: "); Serial.println(rfid.expiry);
+  Serial.print("bio: "); Serial.println(rfid.bio);
+  Serial.print("fluidBlock: "); Serial.println(rfid.fluidBlock);
+  
+  
+  
+}

--- a/Hardware and firmware/Firmware/Classes/Potentiostat.cpp
+++ b/Hardware and firmware/Firmware/Classes/Potentiostat.cpp
@@ -50,7 +50,7 @@ void Potentiostat::scanCV()
     //set up eror checking to check high low etc have been set correctly
     Serial.println("Digital voltage in, Theorectical voltage in (mV), Measured voltage in (mV), Reference voltage (mV), Current (mA)");
     int val = 0;
-    wait = (long)(1000.00/(scan(float)/res));
+    wait = (long)(1000.00/(float(scan)/res));
     Serial.print("Wait is: "); Serial.println(wait);
     ads.begin();
     if(repeat >= 1)

--- a/Hardware and firmware/Firmware/Classes/Potentiostat.h
+++ b/Hardware and firmware/Firmware/Classes/Potentiostat.h
@@ -12,7 +12,6 @@
 #include "ElectroscreenSerial.h"
 #include "Wire.h"
 #include "Adafruit_ADS1015.h"
-#include "unistd.h"
 
 class Potentiostat
 {
@@ -51,6 +50,7 @@ class Potentiostat
         double conv2;
         float conv3;
         int conv4;
+        unsigned long wait;
 
     private:
         int _pwmPin;

--- a/Hardware and firmware/Firmware/Classes/Potentiostat.h
+++ b/Hardware and firmware/Firmware/Classes/Potentiostat.h
@@ -12,6 +12,7 @@
 #include "ElectroscreenSerial.h"
 #include "Wire.h"
 #include "Adafruit_ADS1015.h"
+#include "unistd.h"
 
 class Potentiostat
 {
@@ -25,6 +26,7 @@ class Potentiostat
         int convertVol(int convert);
         void setCV(int h, int l, int s, int r);
         void startWash(SyringeControl control);
+        void initArrays();
 
         //class variables
         volatile int gain[4];

--- a/Hardware and firmware/Firmware/Classes/Potentiostat.h
+++ b/Hardware and firmware/Firmware/Classes/Potentiostat.h
@@ -27,7 +27,7 @@ class Potentiostat
         void startWash(SyringeControl control);
 
         //class variables
-        int gain[4];
+        volatile int gain[4];
         adsGain_t adcSettings[6];
         float oneBitResmV[6];
         int upLimit[6];

--- a/Hardware and firmware/Firmware/Classes/RfidReader.cpp
+++ b/Hardware and firmware/Firmware/Classes/RfidReader.cpp
@@ -9,20 +9,28 @@
 #include "SPI.h"
 #include "MFRC522.h"
 
-#define RST_PIN 53
-#define SS_PIN 5
 
-RfidReader::RfidReader(int connection)
+//THese are the pins used for the Mega - to be re-instated once new board arrives
+//#define RST_PIN 53
+//#define SS_PIN 5
+
+//Nano pins for development
+#define SS_PIN 10;
+#define RST_PIN 9;
+
+MFRC522::StatusCode status;
+MFRC522::MIFARE_Key key;
+int dataBlocks [6];
+String results [6];
+
+RfidReader::RfidReader()
 {
     //initialisation of pins to connection
     MFRC522 mfrc522(SS_PIN, RST_PIN);
-    MFRC522::StatusCode status;
-    MFRC522::MIFARE_Key key;
     SPI.begin();
     for (byte i=0; i < 6; i++) key.keyByte[i] = 0xFF;
     boolean a = 0;
-    int dataBlocks [6];
-    String results [6];
+
 }
 
 String RfidReader::readRfid(int block)
@@ -31,7 +39,7 @@ String RfidReader::readRfid(int block)
 }
 
 int RfidReader::readBlock(int block){
-  /*byte len = 18;
+  byte len = 18;
   byte buffer1[18];
   char strOut[18];
   int val;
@@ -69,5 +77,5 @@ int RfidReader::readBlock(int block){
   Serial.println(strOut);
   Serial.println(val);
   return val; 
-  */
+  
 }

--- a/Hardware and firmware/Firmware/Classes/RfidReader.cpp
+++ b/Hardware and firmware/Firmware/Classes/RfidReader.cpp
@@ -18,64 +18,112 @@
 #define SS_PIN 10;
 #define RST_PIN 9;
 
+MFRC522 mfrc522(SS_PIN, RST_PIN);
 MFRC522::StatusCode status;
 MFRC522::MIFARE_Key key;
-int dataBlocks [6];
-String results [6];
+
 
 RfidReader::RfidReader()
 {
-    //initialisation of pins to connection
-    MFRC522 mfrc522(SS_PIN, RST_PIN);
-    SPI.begin();
-    for (byte i=0; i < 6; i++) key.keyByte[i] = 0xFF;
-    boolean a = 0;
+  int batchBlock =4, analysisBlock =5, cutoffBlock =6,highBlock =8, lowBlock =9, scanBlock =10, repeatBlock =12, expiryBlock =13, bioBlock = 14, fluidBlock = 16;
+  String batch = "", analysis = "", cutoff = "", high = "", low = "", scan = "", repeat = "", expiry = "", bio = "", fluid = "";
+  String descriptor[10] = {"batch", "analysis", "cutoff", "high", "low", "scan", "repeat", "expiry", "bio", "fluid"};
+  byte readBackBlock[18];
+  int blockInt [10] = {batchBlock, analysisBlock, cutoffBlock, highBlock, lowBlock, scanBlock, repeatBlock, expiryBlock, bioBlock, fluidBlock};
+  String parameterOut [10] = {batch,analysis,cutoff,high,low,scan,repeat,expiry, bio, fluid};
 
 }
 
-String RfidReader::readRfid(int block)
+String RfidReader::readRfid()
 {
-    //write function
+    bool mode = getMode();
+    getRfidData();
+    if(mode)
+    {
+      for (int i =0; i <10; i++){
+      char charArray[16];
+      String joinChar = "";
+      byteReadBlock(blockInt[i], readBackBlock);
+      for (int j=0; j<16; j++){
+        charArray[j] = char(readBackBlock[j]);
+      }
+      for (int u=0; u<16; u++){
+        joinChar = joinChar + charArray[u];
+        Serial.write(charArray[u]);
+      }
+      parameterOut[i] = joinChar;
+      Serial.flush();
+    }
+    }
 }
 
-int RfidReader::readBlock(int block){
-  byte len = 18;
-  byte buffer1[18];
-  char strOut[18];
-  int val;
+//METHODS for Serial communication
+bool RfidReader::getMode(){
+  String full;
+  int val = 0;
+  int fullInt = 0;
+  String junk = "";
+  int index;
+  while (Serial.available() == 0);
+  {
+    full = Serial.readStringUntil('\n');
+    while (Serial.available()> 0)
+    { junk = Serial.read(); }
+    index = full.indexOf("True");
+    if (index == -1){
+      return false;
+    }else {
+      return true;
+    }
+  }  
+}
+
+//METHODS FOR RFID READING
+//initialising RFID reader and reading
+void RfidReader::getRfidData(){
+  SPI.begin(); //SPI bus for RFID reader communication
+  mfrc522.PCD_Init(); //RFID reader initialised
+  for (byte i =0; i < 6; i++) key.keyByte[i] = 0xFF; //populating key with default password
+  boolean a = 0; 
+  while (a == 0){
+    boolean x = findCard();
+    a = x;
+  }
+}
+
+//Return True when a RFID is present
+boolean RfidReader::findCard(){
+  if ( ! mfrc522.PICC_IsNewCardPresent()) {
+    return 0;
+  }
+  if( ! mfrc522.PICC_ReadCardSerial()) {
+    return 0;
+  }
+  Serial.println(F("Card Detected"));
+  mfrc522.PICC_DumpDetailsToSerial(&(mfrc522.uid)); //dump details about the card
+  return 1;
+  
+}
+
+//Block reading method
+int RfidReader::byteReadBlock(int block, byte byteArray[]){
+  byte bufferSize = 18;
   int largestModulo4Number = block/4*4;
   byte trailerBlock = largestModulo4Number+3;
-  
-  status = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, trailerBlock, &key, &(mfrc522.uid));
-  if (status != MFRC522::STATUS_OK) {
-    Serial.print(F("Authentication failed: "));
+
+  //Check authentication status
+  byte status = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, trailerBlock, &key, &(mfrc522.uid));
+  if(status != MFRC522::STATUS_OK){
+    Serial.print("PCD_Authenticate() failed (read): ");
     Serial.println(mfrc522.GetStatusCodeName(status));
-    Serial.println("error in PCD_Authenticate code block");
-    return;
+    return 3;//return "3" as error message
   }
 
-  status = mfrc522.MIFARE_Read(block, buffer1, &len);
-  if (status != MFRC522::STATUS_OK) {
-    Serial.print(F("Reading failed: "));
+  //Try to read a block
+  status = mfrc522.MIFARE_Read(block, byteArray, &bufferSize);//&buffersize is a pointer to the buffersize variable; MIFARE_Read requires a pointer instead of just a number
+  if (status != MFRC522::STATUS_OK){
+    Serial.print("MIFARE_read() failed: ");
     Serial.println(mfrc522.GetStatusCodeName(status));
-    Serial.println("Error in MIFARE_Read code block");
-    return;
+    return 4; //4 is returned as an error message
   }
-
-  for (int i = 0; i < 10; i++)
-  {
-      if (buffer1[i] > 44 && buffer1[i] < 58)
-        {
-          Serial.write(buffer1[i]);
-          strOut[i] = buffer1[i];
-          val = atoi(strOut);
-        } else if(buffer1[i] == NULL){
-          return val;
-        }
-  }
-  Serial.println("Never made NULL distinction");
-  Serial.println(strOut);
-  Serial.println(val);
-  return val; 
-  
 }

--- a/Hardware and firmware/Firmware/Classes/RfidReader.cpp
+++ b/Hardware and firmware/Firmware/Classes/RfidReader.cpp
@@ -26,16 +26,28 @@ const int RST_PIN = 9;
 MFRC522 mfrc522(SS_PIN, RST_PIN);
 MFRC522::StatusCode status;
 MFRC522::MIFARE_Key key;
+int batchBlock, analysisBlock, cutoffBlock,highBlock, lowBlock, scanBlock, repeatBlock, expiryBlock, bioBlock, fluidBlock;
+//String batch = "", analysis = "", cutoff = "", rfidHigh = "", rfidLow = "", rfidScan = "", rfidRepeat = "", expiry = "", bio = "", fluid = "";
+String batch, analysis, cutoff, rfidHigh, rfidLow, rfidScan, rfidRepeat, expiry, bio, fluid;
+String descriptor[10];
+byte readBackBlock[18];
+//int blockInt [] = {batchBlock, analysisBlock, cutoffBlock, highBlock, lowBlock, scanBlock, repeatBlock, expiryBlock, bioBlock, fluidBlock};
+int blockInt[10];
+//String parameterOut [] = {batch,analysis,cutoff,rfidHigh,rfidLow,rfidScan,rfidRepeat,expiry, bio, fluid};
+String parameterOut[10];
 
 
 RfidReader::RfidReader()
 {
-  int batchBlock =4, analysisBlock =5, cutoffBlock =6,highBlock =8, lowBlock =9, scanBlock =10, repeatBlock =12, expiryBlock =13, bioBlock = 14, fluidBlock = 16;
-  String batch = "", analysis = "", cutoff = "", high = "", low = "", scan = "", repeat = "", expiry = "", bio = "", fluid = "";
-  String descriptor[10] = {"batch", "analysis", "cutoff", "high", "low", "scan", "repeat", "expiry", "bio", "fluid"};
-  byte readBackBlock[18];
-  int blockInt [10] = {batchBlock, analysisBlock, cutoffBlock, highBlock, lowBlock, scanBlock, repeatBlock, expiryBlock, bioBlock, fluidBlock};
-  String parameterOut [10] = {batch,analysis,cutoff,high,low,scan,repeat,expiry, bio, fluid};
+  //Assigning values of class variables
+  batchBlock =4; analysisBlock =5; cutoffBlock =6;highBlock =8; lowBlock =9; scanBlock =10; repeatBlock =12; expiryBlock =13; bioBlock = 14; fluidBlock = 16;
+  batch = ""; analysis = ""; cutoff = ""; rfidHigh = ""; rfidLow = ""; rfidScan = ""; rfidRepeat = ""; expiry = ""; bio = ""; fluid = "";
+  blockInt[0]=batchBlock; blockInt[1]=analysisBlock; blockInt[2]=cutoffBlock; blockInt[3]=highBlock; blockInt[4]=lowBlock; blockInt[5]=scanBlock; blockInt[6]=repeatBlock;
+  blockInt[7]=expiryBlock; blockInt[8]=bioBlock; blockInt[9]=fluidBlock;  
+  descriptor[0]= "batch"; descriptor[1] = "analysis"; descriptor[2] = "cutoff"; descriptor[3]="high"; descriptor[4]="low"; descriptor[5] ="scan"; descriptor[6]="repeat";
+  descriptor[7]="expiry"; descriptor[8]="biomarker"; descriptor[9]="fluid";
+  parameterOut[0]=batch; parameterOut[1]=analysis; parameterOut[2]=cutoff; parameterOut[3]=rfidHigh; parameterOut[4]=rfidLow; parameterOut[5]=rfidScan; parameterOut[6]=rfidRepeat;
+  parameterOut[7]=expiry; parameterOut[8]=bio; parameterOut[9]=fluidBlock;
 
 }
 
@@ -54,10 +66,10 @@ String RfidReader::readRfid()
       }
       for (int u=0; u<16; u++){
         joinChar = joinChar + charArray[u];
-        Serial.write(charArray[u]);
+        //Serial.write(charArray[u]); 
       }
       parameterOut[i] = joinChar;
-      Serial.flush();
+      //Serial.flush();
     }
     }
 }
@@ -88,7 +100,10 @@ bool RfidReader::getMode(){
 void RfidReader::getRfidData(){
   SPI.begin(); //SPI bus for RFID reader communication
   mfrc522.PCD_Init(); //RFID reader initialised
-  for (byte i =0; i < 6; i++) key.keyByte[i] = 0xFF; //populating key with default password
+  for (byte i =0; i < 6; i++)
+  {
+    key.keyByte[i] = 0xFF; //populating key with default password
+  } 
   boolean a = 0; 
   while (a == 0){
     boolean x = findCard();
@@ -115,12 +130,15 @@ int RfidReader::byteReadBlock(int block, byte byteArray[]){
   byte bufferSize = 18;
   int largestModulo4Number = block/4*4;
   byte trailerBlock = largestModulo4Number+3;
+  byte sts;
 
   //Check authentication status
-  byte sts = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, trailerBlock, &key, &(mfrc522.uid));
+  sts = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, trailerBlock, &key, &(mfrc522.uid)); 
+  //Serial.print("Status:  "); Serial.println(sts);
+  //Serial.print("MFRC522::STATUS_OK:  "); Serial.print(MFRC522::STATUS_OK);
   if(sts != MFRC522::STATUS_OK){
     Serial.print("PCD_Authenticate() failed (read): ");
-    Serial.println(mfrc522.GetStatusCodeName(status));
+    Serial.println(mfrc522.GetStatusCodeName(sts));
     return 3;//return "3" as error message
   }
 
@@ -128,7 +146,7 @@ int RfidReader::byteReadBlock(int block, byte byteArray[]){
   sts = mfrc522.MIFARE_Read(block, byteArray, &bufferSize);//&buffersize is a pointer to the buffersize variable; MIFARE_Read requires a pointer instead of just a number
   if (sts != MFRC522::STATUS_OK){
     Serial.print("MIFARE_read() failed: ");
-    Serial.println(mfrc522.GetStatusCodeName(status));
+    Serial.println(mfrc522.GetStatusCodeName(sts));
     return 4; //4 is returned as an error message
   }
 }

--- a/Hardware and firmware/Firmware/Classes/RfidReader.cpp
+++ b/Hardware and firmware/Firmware/Classes/RfidReader.cpp
@@ -31,7 +31,7 @@ String RfidReader::readRfid(int block)
 }
 
 int RfidReader::readBlock(int block){
-  byte len = 18;
+  /*byte len = 18;
   byte buffer1[18];
   char strOut[18];
   int val;
@@ -69,4 +69,5 @@ int RfidReader::readBlock(int block){
   Serial.println(strOut);
   Serial.println(val);
   return val; 
+  */
 }

--- a/Hardware and firmware/Firmware/Classes/RfidReader.cpp
+++ b/Hardware and firmware/Firmware/Classes/RfidReader.cpp
@@ -27,14 +27,11 @@ MFRC522 mfrc522(SS_PIN, RST_PIN);
 MFRC522::StatusCode status;
 MFRC522::MIFARE_Key key;
 int batchBlock, analysisBlock, cutoffBlock,highBlock, lowBlock, scanBlock, repeatBlock, expiryBlock, bioBlock, fluidBlock;
-//String batch = "", analysis = "", cutoff = "", rfidHigh = "", rfidLow = "", rfidScan = "", rfidRepeat = "", expiry = "", bio = "", fluid = "";
 String batch, analysis, cutoff, rfidHigh, rfidLow, rfidScan, rfidRepeat, expiry, bio, fluid;
 String descriptor[10];
 byte readBackBlock[18];
-//int blockInt [] = {batchBlock, analysisBlock, cutoffBlock, highBlock, lowBlock, scanBlock, repeatBlock, expiryBlock, bioBlock, fluidBlock};
 int blockInt[10];
-//String parameterOut [] = {batch,analysis,cutoff,rfidHigh,rfidLow,rfidScan,rfidRepeat,expiry, bio, fluid};
-String parameterOut[10];
+String* parameterOut[10];
 
 
 RfidReader::RfidReader()
@@ -46,9 +43,8 @@ RfidReader::RfidReader()
   blockInt[7]=expiryBlock; blockInt[8]=bioBlock; blockInt[9]=fluidBlock;  
   descriptor[0]= "batch"; descriptor[1] = "analysis"; descriptor[2] = "cutoff"; descriptor[3]="high"; descriptor[4]="low"; descriptor[5] ="scan"; descriptor[6]="repeat";
   descriptor[7]="expiry"; descriptor[8]="biomarker"; descriptor[9]="fluid";
-  parameterOut[0]=batch; parameterOut[1]=analysis; parameterOut[2]=cutoff; parameterOut[3]=rfidHigh; parameterOut[4]=rfidLow; parameterOut[5]=rfidScan; parameterOut[6]=rfidRepeat;
-  parameterOut[7]=expiry; parameterOut[8]=bio; parameterOut[9]=fluidBlock;
-
+  parameterOut[0]=&batch; parameterOut[1]=&analysis; parameterOut[2]=&cutoff; parameterOut[3]=&rfidHigh; parameterOut[4]=&rfidLow; parameterOut[5]=&rfidScan; parameterOut[6]=&rfidRepeat;
+  parameterOut[7]=&expiry; parameterOut[8]=&bio; parameterOut[9]=&fluid;
 }
 
 String RfidReader::readRfid()
@@ -66,10 +62,8 @@ String RfidReader::readRfid()
       }
       for (int u=0; u<16; u++){
         joinChar = joinChar + charArray[u];
-        //Serial.write(charArray[u]); 
       }
-      parameterOut[i] = joinChar;
-      //Serial.flush();
+      *(parameterOut[i]) = joinChar;
     }
     }
 }
@@ -134,8 +128,6 @@ int RfidReader::byteReadBlock(int block, byte byteArray[]){
 
   //Check authentication status
   sts = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, trailerBlock, &key, &(mfrc522.uid)); 
-  //Serial.print("Status:  "); Serial.println(sts);
-  //Serial.print("MFRC522::STATUS_OK:  "); Serial.print(MFRC522::STATUS_OK);
   if(sts != MFRC522::STATUS_OK){
     Serial.print("PCD_Authenticate() failed (read): ");
     Serial.println(mfrc522.GetStatusCodeName(sts));

--- a/Hardware and firmware/Firmware/Classes/RfidReader.cpp
+++ b/Hardware and firmware/Firmware/Classes/RfidReader.cpp
@@ -6,10 +6,21 @@
 
 #include "Arduino.h"
 #include "RfidReader.h"
+#include "SPI.h"
+#include "MFRC522.h"
+
+#define RST_PIN 53
+#define SS_PIN 5
 
 RfidReader::RfidReader(int connection)
 {
     //initialisation of pins to connection
+    MFRC522 mfrc522(SS_PIN, RST_PIN);
+    MFRC522::StatusCode status;
+    MFRC522::MIFARE_Key key;
+    SPI.begin();
+    for (byte i=0; i < 6; i++) key.keyByte[i] = 0xFF;
+    boolean a = 0;
     int dataBlocks [6];
     String results [6];
 }
@@ -17,4 +28,45 @@ RfidReader::RfidReader(int connection)
 String RfidReader::readRfid(int block)
 {
     //write function
+}
+
+int RfidReader::readBlock(int block){
+  byte len = 18;
+  byte buffer1[18];
+  char strOut[18];
+  int val;
+  int largestModulo4Number = block/4*4;
+  byte trailerBlock = largestModulo4Number+3;
+  
+  status = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, trailerBlock, &key, &(mfrc522.uid));
+  if (status != MFRC522::STATUS_OK) {
+    Serial.print(F("Authentication failed: "));
+    Serial.println(mfrc522.GetStatusCodeName(status));
+    Serial.println("error in PCD_Authenticate code block");
+    return;
+  }
+
+  status = mfrc522.MIFARE_Read(block, buffer1, &len);
+  if (status != MFRC522::STATUS_OK) {
+    Serial.print(F("Reading failed: "));
+    Serial.println(mfrc522.GetStatusCodeName(status));
+    Serial.println("Error in MIFARE_Read code block");
+    return;
+  }
+
+  for (int i = 0; i < 10; i++)
+  {
+      if (buffer1[i] > 44 && buffer1[i] < 58)
+        {
+          Serial.write(buffer1[i]);
+          strOut[i] = buffer1[i];
+          val = atoi(strOut);
+        } else if(buffer1[i] == NULL){
+          return val;
+        }
+  }
+  Serial.println("Never made NULL distinction");
+  Serial.println(strOut);
+  Serial.println(val);
+  return val; 
 }

--- a/Hardware and firmware/Firmware/Classes/RfidReader.cpp
+++ b/Hardware and firmware/Firmware/Classes/RfidReader.cpp
@@ -15,9 +15,14 @@
 //#define SS_PIN 5
 
 //Nano pins for development
-#define SS_PIN 10;
-#define RST_PIN 9;
+//#define SS_PIN 10
+//#define RST_PIN 9
 
+//#define RST_PIN 9
+//#define SS_PIN 10
+
+const int SS_PIN = 10;
+const int RST_PIN = 9;
 MFRC522 mfrc522(SS_PIN, RST_PIN);
 MFRC522::StatusCode status;
 MFRC522::MIFARE_Key key;
@@ -112,16 +117,16 @@ int RfidReader::byteReadBlock(int block, byte byteArray[]){
   byte trailerBlock = largestModulo4Number+3;
 
   //Check authentication status
-  byte status = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, trailerBlock, &key, &(mfrc522.uid));
-  if(status != MFRC522::STATUS_OK){
+  byte sts = mfrc522.PCD_Authenticate(MFRC522::PICC_CMD_MF_AUTH_KEY_A, trailerBlock, &key, &(mfrc522.uid));
+  if(sts != MFRC522::STATUS_OK){
     Serial.print("PCD_Authenticate() failed (read): ");
     Serial.println(mfrc522.GetStatusCodeName(status));
     return 3;//return "3" as error message
   }
 
   //Try to read a block
-  status = mfrc522.MIFARE_Read(block, byteArray, &bufferSize);//&buffersize is a pointer to the buffersize variable; MIFARE_Read requires a pointer instead of just a number
-  if (status != MFRC522::STATUS_OK){
+  sts = mfrc522.MIFARE_Read(block, byteArray, &bufferSize);//&buffersize is a pointer to the buffersize variable; MIFARE_Read requires a pointer instead of just a number
+  if (sts != MFRC522::STATUS_OK){
     Serial.print("MIFARE_read() failed: ");
     Serial.println(mfrc522.GetStatusCodeName(status));
     return 4; //4 is returned as an error message

--- a/Hardware and firmware/Firmware/Classes/RfidReader.h
+++ b/Hardware and firmware/Firmware/Classes/RfidReader.h
@@ -13,8 +13,9 @@ class RfidReader
     public:
         RfidReader(int connection); //update initiation to include all pins needed for control
         String readRfid(int block);
-        int dataBlocks[];
-        String results[];
+        int readBlock(int block);
+        int dataBlocks[6];
+        String results[6];
     private:
         //wiring of pins to be put in here
         int _pin;

--- a/Hardware and firmware/Firmware/Classes/RfidReader.h
+++ b/Hardware and firmware/Firmware/Classes/RfidReader.h
@@ -33,23 +33,14 @@ class RfidReader
         MFRC522::StatusCode status;
         MFRC522::MIFARE_Key key;
 
-        int batchBlock;
-        int analysisBlock;
-        int cutoffBlock;
-        int highBlock;
-        int lowBlock;
-        int scanBlock;
-        int repeatBlock;
-        int expiryBlock;
-        int bioBlock;
-        int fluidBlock;
+        int batchBlock, analysisBlock, cutoffBlock, highBlock, lowBlock, scanBlock, repeatBlock, expiryBlock, bioBlock, fluidBlock;
         String batch;
         String analysis;
         String cutoff;
-        String high;
-        String low;
-        String scan;
-        String repeat;
+        String rfidHigh;
+        String rfidLow;
+        String rfidScan;
+        String rfidRepeat;
         String expiry;
         String bio;
         String fluid;

--- a/Hardware and firmware/Firmware/Classes/RfidReader.h
+++ b/Hardware and firmware/Firmware/Classes/RfidReader.h
@@ -11,14 +11,62 @@
 class RfidReader
 {
     public:
-        RfidReader(int connection); //update initiation to include all pins needed for control
-        String readRfid(int block);
-        int readBlock(int block);
-        int dataBlocks[6];
-        String results[6];
+        //methods
+        RfidReader(); //update initiation to include all pins needed for control
+        String readRfid();
+        bool getMode();
+        void getRfidData();
+        boolean findCard();
+        int byteReadBlock(int block, byte byteArray[]);
+        
+        //variables
+        MFRC522 mfrc522(SS_PIN, RST_PIN);
+        MFRC522::StatusCode status;
+        MFRC522::MIFARE_Key key;
+
+        int batchBlock;
+        int analysisBlock;
+        int cutoffBlock;
+        int highBlock;
+        int lowBlock;
+        int scanBlock;
+        int repeatBlock;
+        int expiryBlock;
+        int bioBlock;
+        int fluidBlock;
+        String batch;
+        String analysis;
+        String cutoff;
+        String high;
+        String low;
+        String scan;
+        String repeat;
+        String expiry;
+        String bio;
+        String fluid;
+        String descriptor[10];
+        byte readBackBlock[18];
+        int blockInt [10];
+        String parameterOut [10];
+
+        bool mode;
+        char charArray[16];
+        String joinChar = "";
+        String full;
+        int val;
+        int fullInt;
+        String junk;
+        int index;
+        boolean a;
+
+        byte bufferSize;
+        int largestModulo4Number;
+        byte trailerBlock;
+        byte status;
+  
+
     private:
         //wiring of pins to be put in here
-        int _pin;
 
 };
 

--- a/Hardware and firmware/Firmware/Classes/RfidReader.h
+++ b/Hardware and firmware/Firmware/Classes/RfidReader.h
@@ -47,7 +47,7 @@ class RfidReader
         String descriptor[10];
         byte readBackBlock[18];
         int blockInt [10];
-        String parameterOut [10];
+        String* parameterOut [10];
 
         bool mode;
         char charArray[16];

--- a/Hardware and firmware/Firmware/Classes/RfidReader.h
+++ b/Hardware and firmware/Firmware/Classes/RfidReader.h
@@ -5,8 +5,15 @@
 */
 #ifndef RfidReader_h
 #define RfidReader_h
+//#define RST_PIN 9
+//#define SS_PIN 10
 
 #include "Arduino.h"
+#include "RfidReader.h"
+#include "MFRC522.h"
+#include "SPI.h"
+
+
 
 class RfidReader
 {
@@ -20,7 +27,9 @@ class RfidReader
         int byteReadBlock(int block, byte byteArray[]);
         
         //variables
-        MFRC522 mfrc522(SS_PIN, RST_PIN);
+        const int SS_PIN = 10;
+        const int RST_PIN = 9;
+        MFRC522 mfrc522;
         MFRC522::StatusCode status;
         MFRC522::MIFARE_Key key;
 
@@ -62,7 +71,7 @@ class RfidReader
         byte bufferSize;
         int largestModulo4Number;
         byte trailerBlock;
-        byte status;
+        byte sts;
   
 
     private:

--- a/Hardware and firmware/Firmware/Classes/SyringeControl.cpp
+++ b/Hardware and firmware/Firmware/Classes/SyringeControl.cpp
@@ -11,7 +11,7 @@
 SyringeControl::SyringeControl()
 {
     int incubations [4];
-    SyringeDriver syringes [4];
+    SyringeDriver syringes [5];
 }
 
 

--- a/Hardware and firmware/Firmware/Classes/SyringeControl.h
+++ b/Hardware and firmware/Firmware/Classes/SyringeControl.h
@@ -27,7 +27,7 @@ class SyringeControl
         void postTest();
 
         //Class variables
-        SyringeDriver syringes [];
+        SyringeDriver syringes [5];
         static int incubations [];
     private:
         //add any pin refs for power management


### PR DESCRIPTION
RfidReader library is able to read the ten blocks assigned for test parameter inputs and identifiers and stores them as class variables. Class-test is now included in the firmware library. Intended to be used to test the firmware using the Arduino IDE. Currently coded for operation by Arduino Nano. Will need small modification upon Mega implementation.